### PR TITLE
feat: support influxdb v2 through influx cli

### DIFF
--- a/database/base.go
+++ b/database/base.go
@@ -94,6 +94,8 @@ func runModel(model config.ModelConfig, dbConfig config.SubConfig) (err error) {
 		db = &SQLite{Base: base}
 	case "mssql":
 		db = &MSSQL{Base: base}
+	case "influxdb2":
+		db = &InfluxDB2{Base: base}
 	default:
 		logger.Warn(fmt.Errorf("model: %s databases.%s config `type: %s`, but is not implement", model.Name, dbConfig.Name, dbConfig.Type))
 		return

--- a/database/influxdb2.go
+++ b/database/influxdb2.go
@@ -1,0 +1,96 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobackup/gobackup/helper"
+	"github.com/gobackup/gobackup/logger"
+)
+
+// MongoDB database
+//
+// type: mongodb
+// host: 127.0.0.1
+// port: 27017
+// database:
+// username:
+// password:
+// authdb:
+// exclude_tables:
+// oplog: false
+// args:
+type InfluxDB2 struct {
+	Base
+	host       string
+	token      string
+	bucket     string
+	bucketId   string
+	org        string
+	orgId      string
+	skipVerify bool
+	httpDebug  bool
+}
+
+func (db *InfluxDB2) init() (err error) {
+	viper := db.viper
+	viper.SetDefault("skipVerify", false)
+	viper.SetDefault("httpDebug", false)
+
+	db.host = viper.GetString("host")
+	db.token = viper.GetString("token")
+	db.bucket = viper.GetString("bucket")
+	db.bucketId = viper.GetString("bucketId")
+	db.org = viper.GetString("org")
+	db.orgId = viper.GetString("orgId")
+	db.skipVerify = viper.GetBool("skipVerify")
+
+	if db.host == "" {
+		return fmt.Errorf("no host specified in influxdb2 configuration: %s", db.name)
+	}
+	if db.token == "" {
+		return fmt.Errorf("no token specified in influxdb2 configuration: %s", db.name)
+	}
+
+	return nil
+}
+
+func (db *InfluxDB2) build() string {
+	opts := make([]string, 0, 15)
+	opts = append(opts, "influx backup")
+	opts = append(opts, "--host="+db.host+"")
+	opts = append(opts, "--token="+db.token+"")
+	if db.bucket != "" {
+		opts = append(opts, "--bucket="+db.bucket+"")
+	}
+	if db.bucketId != "" {
+		opts = append(opts, "--bucket-id="+db.bucketId+"")
+	}
+	if db.org != "" {
+		opts = append(opts, "--org="+db.org+"")
+	}
+	if db.orgId != "" {
+		opts = append(opts, "--org-id="+db.orgId+"")
+	}
+	if db.skipVerify {
+		opts = append(opts, "--skip-verify")
+	}
+	if db.httpDebug {
+		opts = append(opts, "--http-debug")
+	}
+	opts = append(opts, db.dumpPath)
+	return strings.Join(opts, " ")
+}
+
+func (db *InfluxDB2) perform() error {
+	logger := logger.Tag("InfluxDB2")
+
+	command := db.build()
+	out, err := helper.Exec(command)
+	if err != nil {
+		return fmt.Errorf("-> Dump error: %s", err)
+	}
+	logger.Info(out)
+	logger.Info("dump path:", db.dumpPath)
+	return nil
+}


### PR DESCRIPTION
This PR add Influxdb v2 as a source database.

It is required to have [influx cli](https://docs.influxdata.com/influxdb/v2/reference/cli/influx/?t=Linux) installed and in the PATH, at least for of the `gobackup` tool.

An example configuration with influxdb v2 database backup:
```yaml
# gobackup config example
# -----------------------
# Put this file in follow place:
# ~/.gobackup/gobackup.yml or /etc/gobackup/gobackup.yml
# or run the gobackup tool with --config option pointing to this file
web:
  username: gobackup
  password: 123456
models:
  influxdb2_backup:
    description: "Perform local influxdb v2 backup"
    schedule:
      # At 04:05 on Sunday.
      cron: "5 4 * * sun"
    compress_with:
      type: tgz
    default_storage: local
    storages:
      local:
        type: local
        keep: 10
        path: /tmp/gobackup
    databases:
      influxdbv2-oss:
        type: influxdb2
        host: http://localhost:8086
        token: my-token

```

`type`, `token` and `host` properties are required, all other properties of `influxdb2` database are optional:
-  `bucket` (string) - an influxdb bucket to export
-  `bucketId` (string) - an influxdb bucket id to export
-  `org`(string) - an influxdb bucket organization to export
-  `orgId` (string)- an influxdb bucket organization id to export
- `skipVerify` (boolean) - whether to skip TLS certificate verification
- `httpDebug` (boolean) - whether to include HTTP debug messages in the log


